### PR TITLE
fix: ci/cd시 docker compose 명령어 오류 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -83,4 +83,4 @@ jobs:
           password: ${{ secrets.EC2_PASSWORD }}
           script: |
             cd /carrot-coding-backend
-            docker-compose up --force-recreate -d
+            docker compose up --force-recreate -d


### PR DESCRIPTION
ubuntu 환경에서 docker-compose 대신 docker compose ... 명령어를 사용하도록 맞췄습니다.