### PR TITLE
cicd: docker-compose restart 옵션 추가 및 mongodb init script 설정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -81,4 +81,4 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             cd /carrot-coding-backend
-            docker compose up --force-recreate -d
+            docker compose up -d

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ lerna-debug.log*
 # docker
 .data
 docker-compose.yml
+mongo-init.js


### PR DESCRIPTION
- 기존 force-recreate 옵션으로 인해 매 배포 마다 새롭게 컨테이너를 생성하는 문제 해결
- init-mongo.js 를 등록해서 mongodb 초기화를 가능하도록 추가 (보안으로 인해 일단 ignore 처리함. 추후 기회가 된다면 open)