### PR TITLE
일괄 업데이트 청크 개수 조절, 디코딩 방식 변경

### DIFF
--- a/src/domains/data-structure/dataStructure.controller.ts
+++ b/src/domains/data-structure/dataStructure.controller.ts
@@ -49,8 +49,8 @@ export class DataStructureController {
   @Get(':name')
   @UseFilters(BadRequestExceptionFilter)
   async getDetails(@Res() res: Response, @Param('name') name: string) {
-    // replace all '-' to ' '
-    const formattedName = name.replace(/-/gi, ' ');
+    // replace all '+' to ' '
+    const formattedName = name.replace(/\+/gi, ' ');
 
     try {
       const details = await this.dataStructureService.getOne(formattedName);

--- a/src/domains/data-structure/dataStructure.service.ts
+++ b/src/domains/data-structure/dataStructure.service.ts
@@ -73,8 +73,8 @@ export class DataStructureService {
     }
     this.logger.log(`updateAll(${unstableDocuments.length})`);
 
-    // Split 15 docs per chunk
-    const chunks = chunkArray(unstableDocuments, 15);
+    // Split 10 docs per chunk
+    const chunks = chunkArray(unstableDocuments, 10);
     const updatedDocuments = [];
 
     // Request updates on a chunk


### PR DESCRIPTION
기존 인코딩/디코딩
- 공백을 -로 치환하는 인코딩
- -를 다시 공백으로 치환하는 디코딩
- 이 경우 B-tree와 같이 -가 포함된 문자열에 대해서는 오류가 발생함

변경된 인코딩/디코딩
- -대신 +를 사용
- encodeURIComponent 등을 사용할까 고민했지만, 클라이언트-서버 모두 코드 구조가 많이 변경될 것 같아서 미룸